### PR TITLE
fix/debtToken

### DIFF
--- a/src/DebtToken.sol
+++ b/src/DebtToken.sol
@@ -143,7 +143,7 @@ abstract contract DebtToken is ERC4626 {
      * @dev No public transferFrom allowed
      */
     function transferFrom(address, address, uint256) public pure override returns (bool) {
-        revert("DT_TF: TRANSFERFROM_NOT_SUPPORTED");
+        revert("DT_TF: TRANSFER_NOT_SUPPORTED");
     }
 
     /**

--- a/src/DebtToken.sol
+++ b/src/DebtToken.sol
@@ -67,7 +67,7 @@ abstract contract DebtToken is ERC4626 {
     function _deposit(uint256 assets, address receiver) internal returns (uint256 shares) {
         // Check for rounding error since we round down in previewDeposit.
         require((shares = previewDeposit(assets)) != 0, "DT_D: ZERO_SHARES");
-        if (borrowCap > 0) require(balanceOf[receiver] + assets <= borrowCap, "DT_D: BORROW_CAP_EXCEEDED");
+        if (borrowCap > 0) require(maxWithdraw(receiver); + assets <= borrowCap, "DT_D: BORROW_CAP_EXCEEDED");
 
         _mint(receiver, shares);
 

--- a/src/DebtToken.sol
+++ b/src/DebtToken.sol
@@ -39,6 +39,9 @@ abstract contract DebtToken is ERC4626 {
     /**
      * @notice Returns the total amount of outstanding debt in the underlying asset
      * @return totalDebt The total debt in underlying assets
+     * @dev Implementation overwritten in LendingPool.sol which inherits DebtToken.sol
+     * Implementation not vulnerable to ERC4626 inflation attacks,
+     * totaLAssets() does not rely on balanceOf call.
      */
     function totalAssets() public view virtual override returns (uint256) {}
 

--- a/src/DebtToken.sol
+++ b/src/DebtToken.sol
@@ -67,7 +67,7 @@ abstract contract DebtToken is ERC4626 {
     function _deposit(uint256 assets, address receiver) internal returns (uint256 shares) {
         // Check for rounding error since we round down in previewDeposit.
         require((shares = previewDeposit(assets)) != 0, "DT_D: ZERO_SHARES");
-        if (borrowCap > 0) require(maxWithdraw(receiver); + assets <= borrowCap, "DT_D: BORROW_CAP_EXCEEDED");
+        if (borrowCap > 0) require(maxWithdraw(receiver) + assets <= borrowCap, "DT_D: BORROW_CAP_EXCEEDED");
 
         _mint(receiver, shares);
 
@@ -143,7 +143,7 @@ abstract contract DebtToken is ERC4626 {
      * @dev No public transferFrom allowed
      */
     function transferFrom(address, address, uint256) public pure override returns (bool) {
-        revert("DT_TF: TRANSFER_NOT_SUPPORTED");
+        revert("DT_TF: TRANSFROM_NOT_SUPPORTED");
     }
 
     /**

--- a/test/DebtToken.t.sol
+++ b/test/DebtToken.t.sol
@@ -250,7 +250,7 @@ contract TransferTest is DebtTokenTest {
         vm.startPrank(sender);
         // When: sender transferFrom
         // Then: transferFrom should revert with DT_TF: TRANSFERFROM_NOT_SUPPORTED
-        vm.expectRevert("DT_TF: TRANSFERFROM_NOT_SUPPORTED");
+        vm.expectRevert("DT_TF: TRANSFROM_NOT_SUPPORTED");
         debt.transferFrom(from, to, amount);
         vm.stopPrank();
     }


### PR DESCRIPTION
- 43: Add comment that totalAssets() will be overwritten in LendingPool.sol
- preAudit: balanceOf[receiver] returns shares, not the assets → should be maxWithdraw(receiver)
- preAudit: fix revert message
